### PR TITLE
feat(integrations/hubspot-hitl): adding bloc support + fixing client identifier (from botpress/growth#143)

### DIFF
--- a/integrations/hubspot-hitl/integration.definition.ts
+++ b/integrations/hubspot-hitl/integration.definition.ts
@@ -12,7 +12,7 @@ import {
 export default new IntegrationDefinition({
   name: integrationName,
   title: "HubSpot Inbox HITL",
-  version: "5.0.1",
+  version: "5.0.2",
   icon: "icon.svg",
   description:
     "This integration allows your bot to use HubSpot as a HITL provider. Messages will appear in HubSpot Inbox.",

--- a/integrations/hubspot-hitl/src/channels.ts
+++ b/integrations/hubspot-hitl/src/channels.ts
@@ -28,8 +28,8 @@ const getHubspotContextFromMessage = async (props: bp.AnyMessageProps) => {
     name: "userInfo",
     type: "user",
   });
-
-  const name = userInfoState?.state.payload.name;
+  const rawName = userInfoState?.state.payload.name;
+  const name = typeof rawName === "string" ? rawName : "Unknown";
   const phoneNumber = userInfoState?.state.payload.phoneNumber;
   const contactIdentifier = phoneNumber;
   if (!contactIdentifier) {

--- a/integrations/hubspot-hitl/src/channels.ts
+++ b/integrations/hubspot-hitl/src/channels.ts
@@ -1,49 +1,193 @@
-import { conversation } from '@botpress/sdk';
-import * as bp from '../.botpress'
-import { getClient } from './client'
+import * as bp from "../.botpress";
+import { getClient } from "./client";
+import { RuntimeError } from "@botpress/sdk";
+
+const getHubspotContextFromMessage = async (props: bp.AnyMessageProps) => {
+  const { client, ctx, conversation, logger } = props;
+  const hubSpotClient = getClient(
+    ctx,
+    client,
+    ctx.configuration.refreshToken,
+    ctx.configuration.clientId,
+    ctx.configuration.clientSecret,
+    logger,
+  );
+
+  const hubspotConversationId = conversation.tags.id;
+  if (!hubspotConversationId?.length) {
+    logger.forBot().error("No HubSpot Conversation Id");
+    throw new RuntimeError("No HubSpot Conversation Id");
+  }
+
+  const { user: botpressUser } = await client.getOrCreateUser({
+    tags: { hubspotConversationId },
+  });
+
+  const userInfoState = await client.getState({
+    id: botpressUser.id,
+    name: "userInfo",
+    type: "user",
+  });
+
+  const name = userInfoState?.state.payload.name;
+  const phoneNumber = userInfoState?.state.payload.phoneNumber;
+  const contactIdentifier = phoneNumber;
+  if (!contactIdentifier) {
+    logger
+      .forBot()
+      .error(
+        "No user identifier (phone number or email) found in state for HITL.",
+      );
+    throw new RuntimeError("No user identifier found");
+  }
+
+  const integrationThreadId = botpressUser.tags.integrationThreadId as string;
+  return { hubSpotClient, name, contactIdentifier, integrationThreadId };
+};
 
 export const channels = {
   hitl: {
     messages: {
-      text: async ({ client, ctx, conversation, logger, ...props }: bp.AnyMessageProps) => {
-        const hubSpotClient = getClient(ctx, client, ctx.configuration.refreshToken, ctx.configuration.clientId, ctx.configuration.clientSecret, logger);
-   
-        const { text: userMessage } = props.payload
-
-        const hubspotConversationId = conversation.tags.id
-
-        if (!hubspotConversationId?.length) {
-          logger.forBot().error('No HubSpot Conversation Id')
-          return
+      bloc: async (props: bp.AnyMessageProps) => {
+        const { hubSpotClient, name, contactIdentifier, integrationThreadId } =
+          await getHubspotContextFromMessage(props);
+        for (const item of (props as any).payload.items || []) {
+          try {
+            switch (item.type) {
+              case "text":
+                await hubSpotClient.sendMessage(
+                  item.payload.text,
+                  name,
+                  contactIdentifier,
+                  integrationThreadId,
+                );
+                break;
+              case "markdown":
+                await hubSpotClient.sendMessage(
+                  item.payload.markdown,
+                  name,
+                  contactIdentifier,
+                  integrationThreadId,
+                );
+                break;
+              case "image": {
+                const t = item.payload.text ? item.payload.text + " " : " ";
+                await hubSpotClient.sendMessage(
+                  t + item.payload.imageUrl,
+                  name,
+                  contactIdentifier,
+                  integrationThreadId,
+                );
+                break;
+              }
+              case "video": {
+                const t = item.payload.text ? item.payload.text + " " : " ";
+                await hubSpotClient.sendMessage(
+                  t + item.payload.videoUrl,
+                  name,
+                  contactIdentifier,
+                  integrationThreadId,
+                );
+                break;
+              }
+              case "audio": {
+                const t = item.payload.text ? item.payload.text + " " : " ";
+                await hubSpotClient.sendMessage(
+                  t + item.payload.audioUrl,
+                  name,
+                  contactIdentifier,
+                  integrationThreadId,
+                );
+                break;
+              }
+              case "file": {
+                const { fileUrl, title } = item.payload;
+                const text = `${title ? title + ": " : ""}${fileUrl}`;
+                await hubSpotClient.sendMessage(
+                  text,
+                  name,
+                  contactIdentifier,
+                  integrationThreadId,
+                );
+                break;
+              }
+            }
+          } catch (err) {
+            (props.logger || { forBot: () => ({ error: () => {} }) })
+              .forBot()
+              .error(
+                "Failed to send bloc item to HubSpot: " +
+                  (err as Error).message,
+              );
+          }
         }
-       
-        
-        const { user: botpressUser } = await client.getOrCreateUser({
-          tags: {
-            hubspotConversationId: hubspotConversationId,
-          },
-        })
-
-        const userInfoState = await client.getState({
-          id: botpressUser.id,
-          name: "userInfo",
-          type: "user",
-        });
-    
-        if (!userInfoState?.state.payload.phoneNumber) {
-          logger.forBot().error("No userInfo found in state");
-          return {
-            success: false,
-            message: "errorMessage",
-            data: null,
-            conversationId: "error_conversation_id",
-          };; 
+      },
+      file: async (props: bp.AnyMessageProps) => {
+        const { hubSpotClient, name, contactIdentifier, integrationThreadId } =
+          await getHubspotContextFromMessage(props);
+        const { title, fileUrl } = (props.payload as any) || {};
+        if (!fileUrl) {
+          props.logger.forBot().error("No fileUrl provided for file message");
+          throw new RuntimeError("No fileUrl provided for file message");
         }
-
-        const { name, phoneNumber } = userInfoState.state.payload;
+        const text = `${title ? title + ": " : ""}${fileUrl}`;
         return await hubSpotClient.sendMessage(
-          userMessage, name, phoneNumber, botpressUser.tags.integrationThreadId as string)
+          text,
+          name,
+          contactIdentifier,
+          integrationThreadId,
+        );
+      },
+      video: async (props: bp.AnyMessageProps) => {
+        const { hubSpotClient, name, contactIdentifier, integrationThreadId } =
+          await getHubspotContextFromMessage(props);
+        const userMessage = (props.payload as any)?.text || " ";
+        const videoUrl = (props.payload as any)?.videoUrl;
+        const text = `${userMessage}${videoUrl ? " " + videoUrl : ""}`;
+        return await hubSpotClient.sendMessage(
+          text,
+          name,
+          contactIdentifier,
+          integrationThreadId,
+        );
+      },
+      audio: async (props: bp.AnyMessageProps) => {
+        const { hubSpotClient, name, contactIdentifier, integrationThreadId } =
+          await getHubspotContextFromMessage(props);
+        const userMessage = (props.payload as any)?.text || " ";
+        const audioUrl = (props.payload as any)?.audioUrl;
+        const text = `${userMessage}${audioUrl ? " " + audioUrl : ""}`;
+        return await hubSpotClient.sendMessage(
+          text,
+          name,
+          contactIdentifier,
+          integrationThreadId,
+        );
+      },
+      image: async (props: bp.AnyMessageProps) => {
+        const { hubSpotClient, name, contactIdentifier, integrationThreadId } =
+          await getHubspotContextFromMessage(props);
+        const userMessage = (props.payload as any)?.text || " ";
+        const imageUrl = (props.payload as any)?.imageUrl;
+        const text = `${userMessage}${imageUrl ? " " + imageUrl : ""}`;
+        return await hubSpotClient.sendMessage(
+          text,
+          name,
+          contactIdentifier,
+          integrationThreadId,
+        );
+      },
+      text: async (props: bp.AnyMessageProps) => {
+        const { hubSpotClient, name, contactIdentifier, integrationThreadId } =
+          await getHubspotContextFromMessage(props);
+        const userMessage = (props.payload as any)?.text;
+        return await hubSpotClient.sendMessage(
+          userMessage,
+          name,
+          contactIdentifier,
+          integrationThreadId,
+        );
       },
     },
   },
-} satisfies bp.IntegrationProps['channels']
+} satisfies bp.IntegrationProps["channels"];

--- a/integrations/hubspot-hitl/src/client.ts
+++ b/integrations/hubspot-hitl/src/client.ts
@@ -30,7 +30,7 @@ export class HubSpotApi {
     refreshToken: string,
     clientId: string,
     clientSecret: string,
-    logger: bp.Logger
+    logger: bp.Logger,
   ) {
     this.ctx = ctx;
     this.bpClient = bpClient;
@@ -89,7 +89,7 @@ export class HubSpotApi {
           headers: {
             "Content-Type": "application/x-www-form-urlencoded",
           },
-        }
+        },
       );
 
       this.logger
@@ -112,7 +112,7 @@ export class HubSpotApi {
         .forBot()
         .error(
           "Error refreshing access token:",
-          err.response?.data || err.message
+          err.response?.data || err.message,
         );
     }
   }
@@ -131,7 +131,7 @@ export class HubSpotApi {
     endpoint: string,
     method: string = "GET",
     data: any = null,
-    params: any = {}
+    params: any = {},
   ): Promise<any> {
     try {
       const creds = await this.getStoredCredentials();
@@ -247,7 +247,7 @@ export class HubSpotApi {
    */
   async createCustomChannel(
     developerApiKey: string,
-    appId: string
+    appId: string,
   ): Promise<any> {
     const response = await this.makeHitlRequest(
       `${hubspot_api_base_url}/conversations/v3/custom-channels?hapikey=${developerApiKey}&appId=${appId}`,
@@ -272,7 +272,7 @@ export class HubSpotApi {
         channelAccountConnectionRedirectUrl: "https://example.com",
         channelDescription: "Botpress custom channel integration.",
         channelLogoUrl: "https://i.imgur.com/CAu3kb7.png",
-      }
+      },
     );
 
     if (!response.success || !response.data) {
@@ -299,7 +299,7 @@ export class HubSpotApi {
           headers: {
             Accept: "application/json",
           },
-        }
+        },
       );
       return response.data;
     } catch (error: any) {
@@ -307,7 +307,7 @@ export class HubSpotApi {
         .forBot()
         .error(
           "Failed to fetch custom channels:",
-          error.response?.data || error.message
+          error.response?.data || error.message,
         );
       throw error;
     }
@@ -324,7 +324,7 @@ export class HubSpotApi {
   public async connectCustomChannel(
     channelId: string,
     inboxId: string,
-    channelName: string
+    channelName: string,
   ): Promise<any> {
     const endpoint = `https://api.hubapi.com/conversations/v3/custom-channels/${channelId}/channel-accounts`;
 
@@ -364,10 +364,9 @@ export class HubSpotApi {
     channelId: string,
     channelAccountId: string,
     integrationThreadId: string,
-    name: string,
     phoneNumber: string,
     title: string,
-    description: string
+    description: string,
   ): Promise<any> {
     const endpoint = `${hubspot_api_base_url}/conversations/v3/custom-channels/${channelId}/messages`;
     const payload = {
@@ -406,8 +405,8 @@ export class HubSpotApi {
   public async sendMessage(
     message: string,
     senderName: string,
-    senderPhoneNumber: string,
-    integrationThreadId: string
+    contactIdentifier: string,
+    integrationThreadId: string,
   ): Promise<any> {
     const { state } = await this.bpClient.getState({
       id: this.ctx.integrationId,
@@ -428,6 +427,9 @@ export class HubSpotApi {
 
     const endpoint = `${hubspot_api_base_url}/conversations/v3/custom-channels/${channelId}/messages`;
 
+    const isEmail = contactIdentifier.includes("@");
+    const deliveryType = isEmail ? "HS_EMAIL_ADDRESS" : "HS_PHONE_NUMBER";
+
     const payload = {
       type: "MESSAGE",
       text: message,
@@ -438,8 +440,8 @@ export class HubSpotApi {
         {
           name: senderName,
           deliveryIdentifier: {
-            type: "HS_PHONE_NUMBER",
-            value: senderPhoneNumber,
+            type: deliveryType,
+            value: contactIdentifier,
           },
         },
       ],
@@ -472,7 +474,7 @@ export const getClient = (
   refreshToken: string,
   clientId: string,
   clientSecret: string,
-  logger: bp.Logger
+  logger: bp.Logger,
 ) => {
   return new HubSpotApi(
     ctx,
@@ -480,6 +482,6 @@ export const getClient = (
     refreshToken,
     clientId,
     clientSecret,
-    logger
+    logger,
   );
 };

--- a/integrations/hubspot-hitl/src/setup/register.ts
+++ b/integrations/hubspot-hitl/src/setup/register.ts
@@ -1,10 +1,10 @@
-import { getClient } from 'src/client';
+import { getClient } from "src/client";
 import * as bpclient from "@botpress/client";
-import type { RegisterFunction } from '../misc/types';
+import type { RegisterFunction } from "../misc/types";
 
 export const register: RegisterFunction = async ({ ctx, client, logger }) => {
   logger.forBot().info("Registering configuration...");
-  
+
   try {
     const hubspotClient = getClient(
       ctx,
@@ -12,7 +12,7 @@ export const register: RegisterFunction = async ({ ctx, client, logger }) => {
       ctx.configuration.refreshToken,
       ctx.configuration.clientId,
       ctx.configuration.clientSecret,
-      logger
+      logger,
     );
 
     await hubspotClient.refreshAccessToken();
@@ -21,7 +21,7 @@ export const register: RegisterFunction = async ({ ctx, client, logger }) => {
 
     const newChannelId = await hubspotClient.createCustomChannel(
       ctx.configuration.developerApiKey,
-      ctx.configuration.appId
+      ctx.configuration.appId,
     );
 
     logger.forBot().info(`Created custom channel with ID: ${newChannelId}`);
@@ -35,38 +35,57 @@ export const register: RegisterFunction = async ({ ctx, client, logger }) => {
       const channels = await hubspotClient.getCustomChannels();
 
       alreadyConnected = channels.results.some(
-        (channel: any) => channel.id === newChannelId
+        (channel: any) => channel.id === newChannelId,
       );
 
       if (alreadyConnected) {
-        logger.forBot().info(`Channel ID ${newChannelId} found in channel list after ${attempt + 1} attempt(s).`);
+        logger
+          .forBot()
+          .info(
+            `Channel ID ${newChannelId} found in channel list after ${attempt + 1} attempt(s).`,
+          );
         break;
       }
 
       const delay = Math.pow(2, attempt) * 1000;
-      logger.forBot().warn(`Channel ID ${newChannelId} not found yet. Retrying in ${delay / 1000}s...`);
+      logger
+        .forBot()
+        .warn(
+          `Channel ID ${newChannelId} not found yet. Retrying in ${delay / 1000}s...`,
+        );
       await sleep(delay);
       attempt++;
     }
 
     if (alreadyConnected) {
-      logger.forBot().info(`Channel ID ${newChannelId} is already connected. Skipping connection.`);
-    } else {
-      let connectChannel = await hubspotClient.connectCustomChannel(
-        newChannelId,
-        ctx.configuration.inboxId,
-        channelName
-      );
-      logger.forBot().info("Connected new custom channel to inbox.");
-      // Save channelId to integration state
+      const channelsList = await hubspotClient.getCustomChannels();
+      const existing =
+        channelsList.results.find((c: any) => c.id === newChannelId) || {};
+      const channelAccountId =
+        (existing.channelAccounts &&
+          existing.channelAccounts[0] &&
+          existing.channelAccounts[0].id) ||
+        existing.channelAccountId ||
+        existing.id;
       await client.setState({
         id: ctx.integrationId,
         type: "integration",
-        name: 'channelInfo',
-        payload: { 
-          channelId: newChannelId, 
+        name: "channelInfo",
+        payload: { channelId: newChannelId, channelAccountId },
+      });
+    } else {
+      const connectChannel = await hubspotClient.connectCustomChannel(
+        newChannelId,
+        ctx.configuration.inboxId,
+        channelName,
+      );
+      await client.setState({
+        id: ctx.integrationId,
+        type: "integration",
+        name: "channelInfo",
+        payload: {
+          channelId: newChannelId,
           channelAccountId: connectChannel.data.id,
-
         },
       });
     }
@@ -75,11 +94,11 @@ export const register: RegisterFunction = async ({ ctx, client, logger }) => {
   } catch (error) {
     logger.forBot().error("Error during integration registration:", error);
     throw new bpclient.RuntimeError(
-      "Configuration Error! Unable to retrieve app details."
+      "Configuration Error! Unable to retrieve app details.",
     );
   }
 };
 
 function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Passing audio URLs, image URLs, video URLs, etc... whenever a user sends such to fit the new hitl interface update (v2.0.0).

In the last PR, I updated to remove the dependency error but realized this may cause issues if the user does end up sending an audio file / video file. Now it just converts it to URL and sends (as does the intercom hitl / other hitl integrations).

---
_Migrated by bot from **botpress/growth** PR #143._
Original: https://github.com/botpress/growth/pull/143
State in source: closed